### PR TITLE
Write frr related files to /var/lib/neutron/roth/ instead of /etc/neutron/

### DIFF
--- a/src/neutron_roth_agent/__init__.py
+++ b/src/neutron_roth_agent/__init__.py
@@ -49,7 +49,7 @@ def copy_data(source, destination):
                     % (filename, destination)
                 )
         if overwrite:
-            if 'frr.service' in destination:
+            if any(x in destination for x in ['frr.service', 'frr_']):
                 Path(destination).mkdir(parents=True, exist_ok=True)
             shutil.copy(source, destination)
             print("SUCCESS: Copied %s to %s" % (source, destination))
@@ -160,7 +160,7 @@ def create_frr_ns_conf(name):
         get_data(
             name
         ),
-        '/etc/neutron/frr_ns_conf.j2'
+        '/var/lib/neutron/roth/frr_ns_conf.j2'
     )
 
 
@@ -169,7 +169,7 @@ def create_frr_ns_daemons(name):
         get_data(
             name
         ),
-        '/etc/neutron/frr_ns_daemons'
+        '/var/lib/neutron/roth/frr_ns_daemons'
     )
 
 
@@ -178,7 +178,7 @@ def create_frr_ns_service(name):
         get_data(
             name
         ),
-        '/etc/neutron/frr_ns_service.j2'
+        '/var/lib/neutron/roth/frr_ns_service.j2'
     )
 
 

--- a/src/neutron_roth_agent/helpers.py
+++ b/src/neutron_roth_agent/helpers.py
@@ -1022,7 +1022,7 @@ def ensure_frr_ns_dir(ns):
 
 
 def ensure_frr_ns_daemons(ns, router_id):
-    daemons = "/etc/neutron/frr_ns_daemons"
+    daemons = "/var/lib/neutron/roth/frr_ns_daemons"
     ns_daemons = "/etc/frr/%s/daemons" % ns
     service = "frr-%s.service" % router_id
     cp = ["cp", daemons, ns_daemons]
@@ -1058,12 +1058,12 @@ def ensure_frr_ns_daemons(ns, router_id):
 
 def ensure_frr_ns_unit(ns, router_id):
     try:
-        unit_conf = render_template("/etc/neutron/frr_ns_service.j2", namespace=ns)
+        unit_conf = render_template("/var/lib/neutron/roth/frr_ns_service.j2", namespace=ns)
         if not unit_conf:
             return False
 
         service = "frr-%s.service" % router_id
-        filename = "/etc/neutron/frr-%s.service" % router_id
+        filename = "/var/lib/neutron/roth/frr-%s.service" % router_id
         candidate = "%s.candidate" % filename
 
         with open(candidate, "w") as f:
@@ -1222,7 +1222,7 @@ def ensure_frr_namespace(router_id, bgp_id, bgp_peer, router_networks, asn, vrf_
     if len(router_networks) > 1:
         router_networks.sort()
     genconf = render_template(
-        "/etc/neutron/frr_ns_conf.j2",
+        "/var/lib/neutron/roth/frr_ns_conf.j2",
         frr_version=frr_version,
         hostname=hostname,
         asn=asn,


### PR DESCRIPTION
Newer versions of openstack set ownership of /etc/neutron/ to root:root.
This change will drop relevant files into /var/lib/neutron/roth/ instead.
This will prevent the agent from breaking due to permission issues.