### PR TITLE
version 0.0.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,19 +2,35 @@
 
 All notable changes will be documented in this file.
 
+## [0.0.5] - 2023-06-30
+
+### [0.0.5] Added
+
+### [0.0.5] Changed
+
+### [0.0.5] Fixed
+
+- The drop-in unit file for frr is now written to 10-neutron_roth_agent.conf instead
+  of override.conf. This fixes an issue where system administrators may have their
+  own override.conf file installed for frr, and the files would step on each other.
+- _neighbor_manager now runs up to 30 parallel threads. This fixes an issue where
+  having many ARP entries on a node would take the agent longer than the default
+  60s to run.
+- Fixed some cosmetic markdown lint problems in the README and PKG-INFO files.
+
 ## [0.0.4] - 2023-06-14
 
-### Added
+### [0.0.4] Added
 
-### Changed
+### [0.0.4] Changed
 
 - frr related files are now written to /var/lib/neutron/roth instead of /etc/neutron.
 
-### Fixed
+### [0.0.4] Fixed
 
 ## [0.0.3] - 2022-06-20
 
-### Added
+### [0.0.3] Added
 
 - [parseconfig.py](/src/neutron_roth_agent/parseconfig.py)
 - [roth_agent.ini](/src/neutron_roth_agent/data/roth_agent.ini)
@@ -25,9 +41,9 @@ All notable changes will be documented in this file.
   Only prefixes in the same shared address scope as the provider prefix are considered.
   Prefixes must be members of subnet pools.
 
-### Changed
+### [0.0.3] Changed
 
-### Fixed
+### [0.0.3] Fixed
 
 - Fixed a bug in orphan manager where instances of no matching interface types
   would throw an error.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Create the Anycast Gateway on a new bridge and link that bridge to the bridge th
 RotH agent will execute certain tasks on configurable time intervals.
 
 ---
+
 #### Route Manager
 
 A static route is added to a vrf when a transit subnet is attached to a NAT gateway device. This manager will periodically (default: every 30 seconds) check to determine if any static route is still required. It does this by checking if there is a local ARP entry present for the gateway IP address in the static route. If one is not present, an arping is sent, and the condition is checked again. If there is still no entry, the route is deleted. Any related VTYSH configurations are also deleted.
@@ -214,6 +215,7 @@ Further testing is required to ensure there is no case were a route could be del
 </span>
 
 ---
+
 #### Orphan Manager
 
 If instances are deleted from a compute node, it's possible that the network configurations applied by the agent to service those instances are no longer required. This agent will determine if there are no longer any instances present for each configured vrf. If that's the case, the relevant network configurations will be removed:
@@ -224,6 +226,7 @@ If instances are deleted from a compute node, it's possible that the network con
 - FRR configuration
 
 ---
+
 #### Neighbor Manager
 
 This manager will periodically arping every active unicast IP address for each tenant bridge local to the oscomp node. Doing so refreshes the arp timers, and prevents the neighbor entries from transitioning to a stale state. If the IP address does not respond, the timer is not updated, and the entry will timeout as intended.
@@ -233,6 +236,7 @@ If a neighbor entry does reach a stale state, and needs to be revived, the relev
 </span>
 
 ---
+
 #### Reporting
 
 Typical of agent plugins, there is a built-in reporting function to track the state of the agent. The interval is determined by the cfg variables, common to all agents. Example states include:
@@ -267,16 +271,16 @@ pre-commit install
 # Build a source distribution as follows
 python3 -m build --sdist
 # SCP to the destination
-scp dist/neutron-roth-agent-0.0.4.tar.gz root@192.168.1.100:
+scp dist/neutron-roth-agent-0.0.5.tar.gz root@192.168.1.100:
 ```
 
 ### Install neutron-roth-agent
 
 ```bash
 # In the relevant python venv
-cd /openstack/venvs/neutron-21.2.9/
+cd /openstack/venvs/neutron-23.4.3/
 source bin/activate
-pip install /root/neutron-roth-agent-0.0.4.tar.gz
+pip install /root/neutron-roth-agent-0.0.5.tar.gz
 ```
 
 ### Run neutron-roth-agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neutron-roth-agent"
-version = "0.0.4"
+version = "0.0.5"
 description = "Neutron agent for routing on the host"
 license = "Apache-2.0"
 authors = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = neutron-roth-agent
-version = 0.0.4
+version = 0.0.5
 author = Anthony Timmins
 author_email = atimmins@datto.com
 description = Neutron agent for routing on the host

--- a/src/neutron_roth_agent/__init__.py
+++ b/src/neutron_roth_agent/__init__.py
@@ -198,7 +198,7 @@ def main():
         create_eventlet('roth_neutron_agent.py')
         create_filters('roth-agent.filters')
         create_bin('neutron-roth-agent.j2')
-        create_override('override.conf')
+        create_override('10-neutron_roth_agent.conf')
         create_startup('roth_startup.py')
         create_ini('roth_agent.ini')
         create_frr_ns_conf('frr_ns_conf.j2')

--- a/src/neutron_roth_agent/data/10-neutron_roth_agent.conf
+++ b/src/neutron_roth_agent/data/10-neutron_roth_agent.conf
@@ -1,2 +1,3 @@
 [Service]
 ExecStartPost=/usr/bin/python3 /etc/frr/roth_startup.py
+ExecReload=/usr/bin/python3 /etc/frr/roth_startup.py


### PR DESCRIPTION
- The drop-in unit file for frr is now written to 10-neutron_roth_agent.conf instead
  of override.conf. This fixes an issue where system administrators may have their
  own override.conf file installed for frr, and the files would step on each other.
- _neighbor_manager now runs up to 30 parallel threads. This fixes an issue where
  having many ARP entries on a node would take the agent longer than the default
  60s to run.
- Fixed some cosmetic markdown lint problems in the README and PKG-INFO files.