### PR TITLE
Fix VRF-to-VNI mapping creation in roth_startup.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 All notable changes will be documented in this file.
 
+## [0.0.6] - 2025-11-17
+
+### [0.0.6] Added
+
+- Added `get_frr_vrfs()` function to extract VRF information from FRR BGP configuration when kernel VRFs are not present
+
+### [0.0.6] Changed
+
+- Modified `main()` to use FRR BGP configuration as a fallback when no kernel VRFs are found, ensuring VRF-to-VNI mappings are created for FRR-only VRFs
+
+### [0.0.6] Fixed
+
+- Fixed `ensure_frr_config()` function to properly create VRF-to-VNI mappings on startup. The previous implementation used incorrect command construction that prevented vtysh commands from executing in the same session context, requiring manual configuration via vtysh. Commands now execute using multiple `-c` flags in a single vtysh invocation
+
 ## [0.0.5] - 2023-06-30
 
 ### [0.0.5] Added


### PR DESCRIPTION
## Fix VRF-to-VNI mapping creation in roth_startup.py

### Problem

The neutron-roth-agent was failing to properly create VRF-to-VNI mappings on startup, requiring manual configuration via vtysh. Operators had to manually execute commands like:

```bash
vtysh
conf t
vrf vrf5002
vni 5002
exit-vrf
```

This was caused by two issues in roth_startup.py:
Incorrect vtysh command execution: The ensure_frr_config() function used a broken command construction that split vtysh commands across multiple shell invocations, causing each command to lose the session context from the previous command.
Missing FRR-only VRFs: The script only processed kernel VRFs from ip vrf show, but missed FRR-only VRFs that exist in the BGP configuration without corresponding kernel VRFs.
Solution
1. Fixed vtysh command execution (lines 72-79)
Before:
commands = ["sudo /usr/bin/vtysh", "'conf t'"]
config_template = """'vrf %s'
    ' vni %s'
    'exit-vrf'
    """ % (vrf_id, vni)
commands += config_template.split("\n")
execute_command(" -c ".join(commands))
After:
cmd = (
    f"sudo /usr/bin/vtysh "
    f"-c 'conf t' "
    f"-c 'vrf {vrf_id}' "
    f"-c ' vni {vni}' "
    f"-c 'exit-vrf'"
)
execute_command(cmd)
Now all commands execute in a single vtysh session using multiple -c flags, maintaining proper context.
2. Added FRR VRF discovery fallback (lines 190-210)
Added new get_frr_vrfs() function that extracts VRF information from FRR BGP configuration by:
Finding all router bgp <asn> vrf <vrf_name> entries
Deriving VNI from VRF name (e.g., vrf5002 → VNI 5002)
Returning VRF data in the same format as ip vrf show
3. Updated main() to use fallback (lines 224-227)
The main() function now:
First tries to get VRFs from the kernel (ip vrf show)
If empty, falls back to extracting VRFs from FRR BGP config
Processes all discovered VRFs to ensure VRF-to-VNI mappings exist
Testing
Tested on production compute node use1-prod0-os-comp-a-32:
# Remove VRF-to-VNI mapping
sudo /usr/bin/vtysh -c 'conf t' -c 'no vrf vrf5002' -c 'exit'

# Verify it's gone
/usr/bin/vtysh -c "show running-config" | grep -A 2 "^vrf"
# (no output - mapping removed)

# Run updated script
python3 /etc/frr/roth_startup.py

# Verify mapping was recreated
/usr/bin/vtysh -c "show running-config" | grep -A 2 "^vrf"
vrf vrf5002
 vni 5002
exit-vrf
✅ VRF-to-VNI mapping successfully recreated automatically!
Changes
Modified ensure_frr_config() to properly execute vtysh commands in single session
Added get_frr_vrfs() function to extract VRF info from FRR BGP configuration
Updated main() to use FRR BGP config as fallback when kernel VRFs not found
Updated CHANGES.md for version 0.0.6
Impact
This eliminates the need for manual vtysh configuration after agent startup, ensuring VRF-to-VNI mappings are automatically created for both kernel VRFs and FRR-only VRFs. Fixes IAAS-2009