### PR TITLE
Bump version to 0.0.6 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,16 +271,19 @@ pre-commit install
 # Build a source distribution as follows
 python3 -m build --sdist
 # SCP to the destination
-scp dist/neutron-roth-agent-0.0.5.tar.gz root@192.168.1.100:
+scp dist/neutron-roth-agent-0.0.6.tar.gz root@use1-dcs-images:/srv/dcs-images/packages/roth/
 ```
 
 ### Install neutron-roth-agent
 
 ```bash
 # In the relevant python venv
-cd /openstack/venvs/neutron-23.4.3/
+cd openstack/venvs/neutron-25.6.1.dev4
 source bin/activate
-pip install /root/neutron-roth-agent-0.0.5.tar.gz
+pip install /root/neutron-roth-agent-0.0.6.tar.gz
+
+# Start neutron-roth-agent
+systemctl restart neutron-roth-agent.service
 ```
 
 ### Run neutron-roth-agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neutron-roth-agent"
-version = "0.0.5"
+version = "0.0.6"
 description = "Neutron agent for routing on the host"
 license = "Apache-2.0"
 authors = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = neutron-roth-agent
-version = 0.0.5
+version = 0.0.6
 author = Anthony Timmins
 author_email = atimmins@datto.com
 description = Neutron agent for routing on the host


### PR DESCRIPTION
Had to set up an Ubuntu VM in order to install Python 3.7.4 to build a new package.

This PR consists of updating the version bump to 0.0.6.

The new package has been uploaded to `use1-dcs-images`. This package has been tested on a prod0 compute via pip install url into venv.